### PR TITLE
Add button to download the latest desktop release

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,9 @@
               <a class="btn-primary btn-large" href="https://app.cinny.in">
                 <span class="text-s1">Open Cinny</span>
               </a>
+              <a class="btn-primary btn-large" href="https://github.com/cinnyapp/cinny-desktop/releases">
+                <span class="text-s1">Download for Desktop</span>
+              </a>
               <a class="btn-surface btn-large" href="#features">
                 <span class="text-s1">Learn more</span>
               </a>


### PR DESCRIPTION
Just added a button following the website style to get to the GitHub release page and get the latest desktop version, because the page does not really mention the desktop version currently and there should be a download, so people don't think that Cinny can ONLY used in a browser.