### PR TITLE
Make the source button more prominent

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
           <p class="text-b1">Cinny<sup><a title="It is named after The purple sunbird (Cinnyris asiaticus)." href="https://en.wikipedia.org/wiki/Purple_sunbird" target="_blank">[1]</a></sup> is built on top of <a href="https://matrix.org" target="_blank">Matrix</a> — An open network for secure, decentralized communication. We have also made the source code of Cinny open to everyone, so you can enhance, modify and inspect it.</p>
 
           <div class="about__info__btns">
-            <a class="btn-surface btn-large" href="https://github.com/ajbura/cinny" target="_blank">
+            <a class="btn-primary btn-large" href="https://github.com/ajbura/cinny" target="_blank">
               <span class="text-b1">Source code</span>
             </a>
           </div>


### PR DESCRIPTION
Just a small edit I think might be a good quality of life change.

In my first few times going on the site to look for the source code link, I know I often missed the link because it's not really standing out.
Lately I only knew where to click because I remember where it was but I think like that it's standing out a bit more for the first few browse